### PR TITLE
Refactor StreamParser to allow for more efficient coalescing

### DIFF
--- a/benchmarks/src/main/scala/tectonic/BlackholePlate.scala
+++ b/benchmarks/src/main/scala/tectonic/BlackholePlate.scala
@@ -16,7 +16,7 @@
 
 package tectonic
 
-import _root_.fs2.Chunk
+import scala.collection.immutable.List
 
 import org.openjdk.jmh.infra.Blackhole
 
@@ -26,7 +26,7 @@ final class BlackholePlate(
     tinyScalarCost: Long,
     numericCost: Long,
     rowCost: Long,
-    batchCost: Long) extends Plate[Chunk[Nothing]] {
+    batchCost: Long) extends Plate[List[Nothing]] {
 
   import Blackhole.consumeCPU
 
@@ -92,8 +92,8 @@ final class BlackholePlate(
   def finishRow(): Unit =
     consumeCPU(rowCost)
 
-  def finishBatch(terminal: Boolean): Chunk[Nothing] = {
+  def finishBatch(terminal: Boolean): List[Nothing] = {
     consumeCPU(batchCost)
-    Chunk.empty[Nothing]
+    List.empty[Nothing]
   }
 }

--- a/fs2/src/test/scala/tectonic/fs2/StreamParserSpecs.scala
+++ b/fs2/src/test/scala/tectonic/fs2/StreamParserSpecs.scala
@@ -18,8 +18,9 @@ package tectonic
 package fs2
 
 import cats.effect.IO
+import cats.instances.list._
 
-import _root_.fs2.{Chunk, Stream}
+import _root_.fs2.{Chunk, Pipe, Stream}
 
 import tectonic.json.Parser
 import tectonic.test.{Event, ReifiedTerminalPlate}
@@ -28,24 +29,27 @@ import org.specs2.mutable.Specification
 
 import scodec.bits.ByteVector
 
-import scala.List
+import scala.{Byte, List}
 
 import java.nio.ByteBuffer
 
 object StreamParserSpecs extends Specification {
   import Event._
 
-  val parserF: IO[BaseParser[Chunk[Event]]] =
-    IO(Parser(new ReifiedTerminalPlate().mapDelegate(Chunk.seq(_)), Parser.ValueStream))
+  val parserF: IO[BaseParser[List[Event]]] =
+    IO(Parser(new ReifiedTerminalPlate(), Parser.ValueStream))
+
+  val parser: Pipe[IO, Byte, Event] =
+    StreamParser.foldable(parserF)
 
   "stream parser transduction" should {
     "parse a single value" in {
-      val results = Stream.chunk(Chunk.Bytes("42".getBytes)).through(StreamParser(parserF))
+      val results = Stream.chunk(Chunk.Bytes("42".getBytes)).through(parser)
       results.compile.toList.unsafeRunSync mustEqual List(Num("42", -1, -1), FinishRow)
     }
 
     "parse a two values from a single chunk" in {
-      val results = Stream.chunk(Chunk.Bytes("42 true".getBytes)).through(StreamParser(parserF))
+      val results = Stream.chunk(Chunk.Bytes("42 true".getBytes)).through(parser)
       val expected = List(Num("42", -1, -1), FinishRow, Tru, FinishRow)
 
       results.compile.toList.unsafeRunSync mustEqual expected
@@ -55,7 +59,7 @@ object StreamParserSpecs extends Specification {
       val input = Stream.chunk(Chunk.Bytes("4".getBytes)) ++
         Stream.chunk(Chunk.Bytes("2".getBytes))
 
-      val results = input.through(StreamParser(parserF))
+      val results = input.through(parser)
       val expected = List(Num("42", -1, -1), FinishRow)
 
       results.compile.toList.unsafeRunSync mustEqual expected
@@ -65,7 +69,7 @@ object StreamParserSpecs extends Specification {
       val input = Stream.chunk(Chunk.Bytes("42 ".getBytes)) ++
         Stream.chunk(Chunk.Bytes("true".getBytes))
 
-      val results = input.through(StreamParser(parserF))
+      val results = input.through(parser)
       val expected = List(Num("42", -1, -1), FinishRow, Tru, FinishRow)
 
       results.compile.toList.unsafeRunSync mustEqual expected
@@ -74,7 +78,7 @@ object StreamParserSpecs extends Specification {
     "parse a value from a bytebuffer chunk" in {
       val input = Stream.chunk(Chunk.ByteBuffer(ByteBuffer.wrap("42".getBytes)))
 
-      val results = input.through(StreamParser(parserF))
+      val results = input.through(parser)
       val expected = List(Num("42", -1, -1), FinishRow)
 
       results.compile.toList.unsafeRunSync mustEqual expected
@@ -86,7 +90,7 @@ object StreamParserSpecs extends Specification {
           ByteVector.view(ByteBuffer.wrap("42 ".getBytes)) ++
             ByteVector.view(ByteBuffer.wrap("true".getBytes))))
 
-      val results = input.through(StreamParser(parserF))
+      val results = input.through(parser)
       val expected = List(Num("42", -1, -1), FinishRow, Tru, FinishRow)
 
       results.compile.toList.unsafeRunSync mustEqual expected


### PR DESCRIPTION
Provides more control over how multiple results from a parser are combined to form a `Chunk`, allowing retraversal of the results to be avoided in many cases.