### PR TITLE
It's vastly more useful to use BaseParser on the constructors

### DIFF
--- a/core/src/main/scala/tectonic/csv/Parser.scala
+++ b/core/src/main/scala/tectonic/csv/Parser.scala
@@ -501,7 +501,7 @@ final class Parser[F[_], A](plate: Plate[A], config: Parser.Config) extends Base
 
 object Parser {
 
-  def apply[F[_]: Sync, A](plateF: F[Plate[A]], config: Config): F[Parser[F, A]] = {
+  def apply[F[_]: Sync, A](plateF: F[Plate[A]], config: Config): F[BaseParser[F, A]] = {
     plateF flatMap { plate =>
       Sync[F].delay(new Parser[F, A](plate, config))
     }

--- a/core/src/main/scala/tectonic/json/Parser.scala
+++ b/core/src/main/scala/tectonic/json/Parser.scala
@@ -864,7 +864,7 @@ object Parser {
     Array(
       "org.wartremover.warts.DefaultArguments",
       "org.wartremover.warts.Null"))
-  def apply[F[_]: Sync, A](plateF: F[Plate[A]], mode: Mode = SingleValue) : F[Parser[F, A]] = {
+  def apply[F[_]: Sync, A](plateF: F[Plate[A]], mode: Mode = SingleValue) : F[BaseParser[F, A]] = {
     plateF flatMap { plate =>
       Sync[F].delay(new Parser(plate, state = mode.start,
         ring = 0L, roffset = -1, fallback = null,


### PR DESCRIPTION
This fixes a bunch of inference things when you use the parser constructors with `BaseParser`, especially when using some polymorphic effect `F[_]` and not `IO` directly.