### PR TITLE
Fix the fact that csv.Parser isn't actually memory-safe

### DIFF
--- a/core/src/main/scala/tectonic/csv/Parser.scala
+++ b/core/src/main/scala/tectonic/csv/Parser.scala
@@ -80,6 +80,7 @@ final class Parser[F[_], A](plate: Plate[A], config: Parser.Config) extends Base
       "org.wartremover.warts.NonUnitStatements"))
   protected[this] final def churn(): Either[ParseException, A] = {
     try {
+      offset = reset(offset)
       parse(state, curr, column)
     } catch {
       case AsyncException =>
@@ -302,6 +303,7 @@ final class Parser[F[_], A](plate: Plate[A], config: Parser.Config) extends Base
 
     this.state = state
     this.curr = i
+    this.offset = i
     this.column = column
 
     val inHeader = (state & HEADER_MASK) == HEADER


### PR DESCRIPTION
Whoops…

I think we could probably merge `offset` and `curr`. I'm not entirely sure if they serve a purpose in their currently-separated form. At least this makes it so that things *work*. Verified with a 1.9 GB CSV.

Also, this has the pleasing side-effect of slightly improving performance. Run on battery power with 5 warmups and 5 iterations:

**Before:**

```
Benchmark                             (framework)  Mode  Cnt     Score     Error  Units
ParserBenchmarks.lineCountThroughFs2     tectonic  avgt    5   224.858 ±  12.075  ms/op
ParserBenchmarks.parseThroughFs2         tectonic  avgt    5  2026.964 ± 104.686  ms/op
```

**After:**

```
Benchmark                             (framework)  Mode  Cnt     Score    Error  Units
ParserBenchmarks.lineCountThroughFs2     tectonic  avgt    5   228.476 ± 11.375  ms/op
ParserBenchmarks.parseThroughFs2         tectonic  avgt    5  1924.412 ± 17.209  ms/op
```

So roughly a 5-7% performance improvement.

Fixes #25 
[ch3261]