### PR TITLE
SkipColumn support in JSON backend

### DIFF
--- a/benchmarks/src/main/scala/tectonic/json/FacadeTuningParams.scala
+++ b/benchmarks/src/main/scala/tectonic/json/FacadeTuningParams.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tectonic.json
+
+import scala.Long
+
+// optimized columnar plate vs optimized row facade (invented out of thin air by Daniel and Alissa 😁)
+private[json] object FacadeTuningParams {
+  object Tectonic {
+    val VectorCost: Long = 4   // Cons object allocation + memory store
+    val TinyScalarCost: Long = 8    // hashmap get + bitset put
+    val ScalarCost: Long = 16   // hashmap get + check on array + amortized resize/allocate + array store
+    val RowCost: Long = 2   // increment integer + bounds check + amortized reset
+    val BatchCost: Long = 1   // (maybe) reset state + bounds check
+  }
+
+  val NumericCost: Long = 512   // scalarCost + crazy numeric shenanigans
+
+  object Jawn {
+    val VectorAddCost: Long = 32   // hashmap something + checks + allocations + stuff
+    val VectorFinalCost: Long = 4   // final allocation + memory store
+    val ScalarCost: Long = 2     // object allocation
+    val TinyScalarCost: Long = 1   // non-volatile memory read
+  }
+}

--- a/benchmarks/src/main/scala/tectonic/json/SkipBenchmarks.scala
+++ b/benchmarks/src/main/scala/tectonic/json/SkipBenchmarks.scala
@@ -97,7 +97,7 @@ private[json] final class ProjectionPlate[A] private (
   private[this] val SkipColumn = if (enableSkips) Signal.SkipColumn else Signal.Continue
 
   override def nestMap(pathComponent: CharSequence): Signal = {
-    if (under <= 0 && pathComponent == field) {
+    if (under <= 0 && pathComponent.toString == field) {
       under += 1
       super.nestMap(pathComponent)
     } else if (under > 0) {

--- a/benchmarks/src/main/scala/tectonic/json/SkipBenchmarks.scala
+++ b/benchmarks/src/main/scala/tectonic/json/SkipBenchmarks.scala
@@ -17,12 +17,10 @@
 package tectonic
 package json
 
-import cats.effect.{ContextShift, IO}
+import cats.effect.{ContextShift, IO, Sync}
 
 import _root_.fs2.Chunk
 import _root_.fs2.io.file
-
-import jawnfs2._
 
 import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Param, Scope, State}
 import org.openjdk.jmh.infra.Blackhole
@@ -38,10 +36,7 @@ import java.util.concurrent.{Executors, TimeUnit}
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))
 @State(Scope.Benchmark)
-class ParserBenchmarks {
-  val TectonicFramework = "tectonic"
-  val JawnFramework = "jawn"
-
+class SkipBenchmarks {
   private[this] implicit val CS: ContextShift[IO] =
     IO.contextShift(ExecutionContext.global)
 
@@ -59,65 +54,71 @@ class ParserBenchmarks {
 
   import FacadeTuningParams._
 
-  // params
-
-  @Param(Array("tectonic", "jawn"))
-  var framework: String = _
-
-  @Param(Array(
-    "bar (not wrapped)",
-    "bla2 (not wrapped)",
-    "bla25 (wrapped)",
-    "countries.geo (not wrapped)",
-    "dkw-sample (not wrapped)",
-    "foo (wrapped)",
-    "qux1 (not wrapped)",
-    "qux2 (not wrapped)",
-    "ugh10k (wrapped)"))
-  var input: String = _
-
-  // benchmarks
+  @Param(Array("true", "false"))
+  var enableSkips: Boolean = _
 
   // includes the cost of file IO; not sure if that's a good thing?
   @Benchmark
-  def parseThroughFs2(bh: Blackhole): Unit = {
-    val modeStart = input.indexOf('(')
-    val inputMode = input.substring(modeStart + 1, input.length - 1) == "wrapped"
-    val inputFile = input.substring(0, modeStart - 1)
+  def projectBarKeyFromUgh10k(bh: Blackhole): Unit = {
+    val plateF = for {
+      terminal <- BlackholePlate[IO](
+        Tectonic.VectorCost,
+        Tectonic.ScalarCost,
+        Tectonic.TinyScalarCost,
+        NumericCost,
+        Tectonic.RowCost,
+        Tectonic.BatchCost)
 
-    val plateF = BlackholePlate[IO](
-      Tectonic.VectorCost,
-      Tectonic.ScalarCost,
-      Tectonic.TinyScalarCost,
-      NumericCost,
-      Tectonic.RowCost,
-      Tectonic.BatchCost)
-
-    implicit val facade = new BlackholeFacade(
-      Jawn.VectorAddCost,
-      Jawn.VectorFinalCost,
-      Jawn.ScalarCost,
-      Jawn.TinyScalarCost,
-      NumericCost)
+      back <- ProjectionPlate[IO, List[Nothing]](terminal, "bar", enableSkips)
+    } yield back
 
     val contents = file.readAll[IO](
-      ResourceDir.resolve(inputFile + ".json"),
+      ResourceDir.resolve("ugh10k.json"),
       BlockingEC,
       ChunkSize)
 
-    val processed = if (framework == TectonicFramework) {
-      val mode = if (inputMode) Parser.UnwrapArray else Parser.ValueStream
-      val parser = StreamParser(Parser(plateF, mode): IO[BaseParser[IO, List[Nothing]]])(
-        _ => Chunk.empty[Nothing],
-        _ => Chunk.empty[Nothing])
-      contents.through(parser)
-    } else {
-      if (inputMode)
-        contents.chunks.unwrapJsonArray
-      else
-        contents.chunks.parseJsonStream
-    }
+    val parser = StreamParser(Parser(plateF, Parser.UnwrapArray))(
+      _ => Chunk.empty[Nothing],
+      _ => Chunk.empty[Nothing])
 
-    processed.compile.drain.unsafeRunSync()
+    contents.through(parser).compile.drain.unsafeRunSync()
   }
+}
+
+private[json] final class ProjectionPlate[A] private (
+    delegate: Plate[A],
+    field: String,
+    enableSkips: Boolean)
+    extends DelegatingPlate(delegate) {
+
+  private[this] final var under: Int = 0
+
+  private[this] val Continue = Signal.Continue
+  private[this] val SkipColumn = if (enableSkips) Signal.SkipColumn else Signal.Continue
+
+  override def nestMap(pathComponent: CharSequence): Signal = {
+    if (under <= 0 && pathComponent == field) {
+      under += 1
+      super.nestMap(pathComponent)
+    } else if (under > 0) {
+      under += 1
+      super.nestMap(pathComponent)
+    } else {
+      SkipColumn
+    }
+  }
+
+  override def unnest(): Signal = {
+    if (under > 0) {
+      under -= 1
+      super.unnest()
+    } else {
+      Continue
+    }
+  }
+}
+
+private[json] object ProjectionPlate {
+  def apply[F[_]: Sync, A](delegate: Plate[A], field: String, enableSkips: Boolean): F[Plate[A]] =
+    Sync[F].delay(new ProjectionPlate(delegate, field, enableSkips))
 }

--- a/core/src/main/scala/tectonic/DelegatingPlate.scala
+++ b/core/src/main/scala/tectonic/DelegatingPlate.scala
@@ -60,4 +60,7 @@ abstract class DelegatingPlate[A](val delegate: Plate[A]) extends Plate[A] {
 
   def finishBatch(terminal: Boolean): A =
     delegate.finishBatch(terminal)
+
+  override def skipped(bytes: Int): Unit =
+    delegate.skipped(bytes)
 }

--- a/core/src/main/scala/tectonic/Plate.scala
+++ b/core/src/main/scala/tectonic/Plate.scala
@@ -38,6 +38,9 @@ abstract class Plate[A] { self =>
   def finishRow(): Unit
   def finishBatch(terminal: Boolean): A
 
+  // TODO make this abstract in the next breaking release
+  def skipped(bytes: Int): Unit = ()
+
   final def mapDelegate[B](f: A => B): Plate[B] = new Plate[B] {
     def nul(): Signal = self.nul()
     def fls(): Signal = self.fls()
@@ -57,5 +60,7 @@ abstract class Plate[A] { self =>
 
     override def finishBatch(terminal: Boolean): B =
       f(self.finishBatch(terminal))
+
+    override def skipped(bytes: Int): Unit = self.skipped(bytes)
   }
 }

--- a/core/src/main/scala/tectonic/json/Parser.scala
+++ b/core/src/main/scala/tectonic/json/Parser.scala
@@ -61,6 +61,7 @@ import scala.{
   Right,
   Unit
 }
+// import scala._, Predef._
 import scala.annotation.{switch, tailrec}
 
 import java.lang.{CharSequence, IndexOutOfBoundsException, SuppressWarnings}
@@ -851,7 +852,7 @@ final class Parser[F[_], A] private (
 
     // don't bother checkpointing every time when we skip
     val c = if (i >= unsafeLen() - 2) {
-      checkpoint(state, i, ring, offset, fallback)
+      checkpoint(state, i, ring, roffset, fallback)
       at(i)
     } else {
       // skip the redundant bounds check
@@ -880,14 +881,14 @@ final class Parser[F[_], A] private (
 
           case ']' | '}' =>
             if (skipDepth <= 0) {
-              rparse(if (enclosure(ring, offset, fallback)) OBJEND else ARREND, i, ring, offset, fallback)
+              rparse(if (enclosure(ring, roffset, fallback)) OBJEND else ARREND, i, ring, roffset, fallback)
             } else {
               val skipDepthBits = (skipDepth - 1) << SKIP_DEPTH_SHIFT
               rskip(skipDepthBits | SKIP_MAIN, i + 1)
             }
 
           case ',' if skipDepth == 0 =>
-            rparse(if (enclosure(ring, offset, fallback)) OBJEND else ARREND, i, ring, offset, fallback)
+            rparse(if (enclosure(ring, roffset, fallback)) OBJEND else ARREND, i, ring, roffset, fallback)
 
           case _ => rskip(state, i + 1)
         }

--- a/core/src/main/scala/tectonic/json/Parser.scala
+++ b/core/src/main/scala/tectonic/json/Parser.scala
@@ -156,6 +156,30 @@ final class Parser[F[_], A] private (
   @inline private[this] final val ARREND = 4
   @inline private[this] final val OBJEND = 5
 
+  @inline private[this] final val SKIP_MAIN = 8
+  @inline private[this] final val SKIP_STRING = 9
+
+  /*
+   * This is slightly tricky. We're using the otherwise-unused
+   * high order bits of `state` to track the depth of the structural
+   * nesting when we are skipping. We can do this because we know
+   * that the depth will always be positive. We posit that 134,217,727
+   * levels is enough nesting for anyone.
+   */
+
+  @inline private[this] final val SKIP_DEPTH_SHIFT = 4
+
+  // remove the sign and lowest four bits
+  @inline private[this] final val SKIP_DEPTH_MASK =
+    ~(Int.MinValue | (1 << SKIP_DEPTH_SHIFT) - 1)
+
+  @inline private[this] final val SKIP_DEPTH_LIMIT = (2 << (31 - 4)) - 1
+
+  // private[this] final val Continue = Signal.Continue
+  private[this] final val SkipColumn = Signal.SkipColumn
+  // private[this] final val SkipRow = Signal.SkipRow
+  // private[this] final val Terminate = Signal.Terminate
+
   @SuppressWarnings(Array("org.wartremover.warts.While"))
   private[this] val HexChars: Array[Int] = {
     val arr = new Array[Int](128)
@@ -234,11 +258,14 @@ final class Parser[F[_], A] private (
         } else {
           // jump straight back into rparse
           offset = reset(offset)
-          val j = if (state <= 0) {
+
+          val j = if (state <= 0)
             parse(offset)
-          } else {
+          else if (state >= 8)
+            rskip(state, curr)
+          else
             rparse(state, curr, ring, roffset, fallback)
-          }
+
           if (streamMode > 0) {
             state = ASYNC_POSTVAL
           } else if (streamMode == 0) {
@@ -498,12 +525,13 @@ final class Parser[F[_], A] private (
       "org.wartremover.warts.NonUnitStatements",
       "org.wartremover.warts.While",
       "org.wartremover.warts.Return"))
-  protected[this] def parseString(i: Int, key: Boolean): Int = {
+  protected[this] def parseString(i: Int, key: Boolean): Boolean = {
     val k = parseStringSimple(i + 1)
     if (k != -1) {
       val cs = at(i + 1, k - 1)
-      if (key) plate.nestMap(cs) else plate.str(cs)
-      return k
+      val s = if (key) plate.nestMap(cs) else plate.str(cs)
+      this.curr = k
+      return (s ne SkipColumn)
     }
 
     // TODO: we might be able to do better by identifying where
@@ -555,8 +583,9 @@ final class Parser[F[_], A] private (
       }
       c = byte(j) & 0xff
     }
-    if (key) plate.nestMap(sb.makeString) else plate.str(sb.makeString)
-    j + 1
+    val s = if (key) plate.nestMap(sb.makeString) else plate.str(sb.makeString)
+    this.curr = j + 1
+    s ne SkipColumn
   }
 
   /**
@@ -630,9 +659,9 @@ final class Parser[F[_], A] private (
 
       // we have a single top-level string
       case '"' =>
-        val j = parseString(i, false)
+        val _ = parseString(i, false)
         plate.finishRow()
-        j
+        curr
 
       // we have a single top-level constant
       case 't' =>
@@ -721,8 +750,8 @@ final class Parser[F[_], A] private (
           val j = parseNum(i)
           rparse(if (enclosure(ring, offset, fallback)) OBJEND else ARREND, j, ring, offset, fallback)
         } else if (c == '"') {
-          val j = parseString(i, false)
-          rparse(if (enclosure(ring, offset, fallback)) OBJEND else ARREND, j, ring, offset, fallback)
+          parseString(i, false)
+          rparse(if (enclosure(ring, offset, fallback)) OBJEND else ARREND, curr, ring, offset, fallback)
         } else if (c == 't') {
           parseTrue(i)
           rparse(if (enclosure(ring, offset, fallback)) OBJEND else ARREND, i + 4, ring, offset, fallback)
@@ -766,7 +795,10 @@ final class Parser[F[_], A] private (
     } else if (state == KEY) {
       // we are in an object expecting to see a key.
       if (c == '"') {
-        rparse(SEP, parseString(i, true), ring, offset, fallback)
+        if (parseString(i, true))
+          rparse(SEP, curr, ring, offset, fallback)
+        else
+          rskip(SKIP_MAIN, curr)
       } else {
         die(i, "expected \"")
       }
@@ -781,8 +813,10 @@ final class Parser[F[_], A] private (
       // we are in an array, expecting to see a comma (before more data).
       if (c == ',') {
         plate.unnest()
-        plate.nestArr()
-        rparse(DATA, i + 1, ring, offset, fallback)
+        if (plate.nestArr() eq SkipColumn)
+          rskip(SKIP_MAIN, i + 1)
+        else
+          rparse(DATA, i + 1, ring, offset, fallback)
       } else {
         die(i, "expected ] or ,")
       }
@@ -796,11 +830,77 @@ final class Parser[F[_], A] private (
       }
     } else if (state == ARRBEG) {
       // we are starting an array, expecting to see data or a closing bracket.
-      plate.nestArr()
-      rparse(DATA, i, ring, offset, fallback)
+      if (plate.nestArr() eq SkipColumn)
+        rskip(SKIP_MAIN, i)
+      else
+        rparse(DATA, i, ring, offset, fallback)
     } else {
       // we are starting an object, expecting to see a key or a closing brace.
       rparse(KEY, i, ring, offset, fallback)
+    }
+  }
+
+  @tailrec
+  @SuppressWarnings(
+    Array(
+      "org.wartremover.warts.NonUnitStatements",
+      "org.wartremover.warts.Equals"))
+  private[this] final def rskip(state: Int, j: Int): Int = {
+    // we might miss parse errors within a skip block (e.g. closing an object with ']'). this is by design
+    val i = reset(j)
+
+    // don't bother checkpointing every time when we skip
+    val c = if (i >= unsafeLen() - 2) {
+      checkpoint(state, i, ring, offset, fallback)
+      at(i)
+    } else {
+      // skip the redundant bounds check
+      unsafeData()(i).toChar
+    }
+
+    if (c == '\n') {
+      newline(i)
+    }
+
+    // we're hiding our structural depth within the high-order bits to avoid extra integers
+    val realState = state & ~SKIP_DEPTH_MASK
+    val skipDepthBits = state & SKIP_DEPTH_MASK
+    val skipDepth = skipDepthBits >> SKIP_DEPTH_SHIFT
+
+    (realState: @switch) match {
+      case SKIP_MAIN =>
+        (c: @switch) match {
+          case '"' => rskip(skipDepthBits | SKIP_STRING, i + 1)
+
+          case '{' | '[' =>
+            val skipDepth2 = skipDepth + 1
+            if (skipDepth2 >= SKIP_DEPTH_LIMIT) error("cannot skip over structure with more than 134,217,727 levels of nesting")
+            val skipDepthBits = skipDepth2 << SKIP_DEPTH_SHIFT
+            rskip(skipDepthBits | SKIP_MAIN, i + 1)
+
+          case ']' | '}' =>
+            if (skipDepth <= 0) {
+              rparse(if (enclosure(ring, offset, fallback)) OBJEND else ARREND, i, ring, offset, fallback)
+            } else {
+              val skipDepthBits = (skipDepth - 1) << SKIP_DEPTH_SHIFT
+              rskip(skipDepthBits | SKIP_MAIN, i + 1)
+            }
+
+          case ',' if skipDepth == 0 =>
+            rparse(if (enclosure(ring, offset, fallback)) OBJEND else ARREND, i, ring, offset, fallback)
+
+          case _ => rskip(state, i + 1)
+        }
+
+      case SKIP_STRING =>
+        (c: @switch) match {
+          case '\\' => rskip(skipDepthBits | SKIP_STRING, i + 2)
+          case '"' => rskip(skipDepthBits | SKIP_MAIN, i + 1)
+          case _ => rskip(state, i + 1)
+        }
+
+      case _ =>
+        error("invalid state in rskip: " + state.toString)
     }
   }
 

--- a/core/src/main/scala/tectonic/json/Parser.scala
+++ b/core/src/main/scala/tectonic/json/Parser.scala
@@ -863,7 +863,7 @@ final class Parser[F[_], A] private (
     val i = reset(j)
 
     // don't bother checkpointing every time when we skip
-    val c = if (i >= unsafeLen() - 1) {
+    val c = if (i > unsafeLen() - 1) {
       plate.skipped(i - curr)
       checkpoint(state, i, ring, roffset, fallback)
       at(i)

--- a/test/src/main/scala/tectonic/test/Event.scala
+++ b/test/src/main/scala/tectonic/test/Event.scala
@@ -39,4 +39,6 @@ object Event {
   case object Unnest extends Event
 
   case object FinishRow extends Event
+
+  final case class Skipped(bytes: Int) extends Event
 }

--- a/test/src/main/scala/tectonic/test/ReifiedTerminalPlate.scala
+++ b/test/src/main/scala/tectonic/test/ReifiedTerminalPlate.scala
@@ -96,6 +96,12 @@ final class ReifiedTerminalPlate private () extends Plate[List[Event]] {
     events.clear()
     back
   }
+
+  override def skipped(bytes: Int): Unit = {
+    if (bytes > 0) {
+      events += Skipped(bytes)
+    }
+  }
 }
 
 object ReifiedTerminalPlate {
@@ -117,6 +123,7 @@ object ReifiedTerminalPlate {
       case Event.NestMeta(path) => plate.nestMeta(path)
       case Event.Unnest => plate.unnest()
       case Event.FinishRow => plate.finishRow()
+      case Event.Skipped(bytes) => plate.skipped(bytes)
     }
 
     plate.finishBatch(true)

--- a/test/src/main/scala/tectonic/test/json/package.scala
+++ b/test/src/main/scala/tectonic/test/json/package.scala
@@ -23,7 +23,7 @@ import org.specs2.matcher.{Matcher, MatchersImplicits}
 
 import tectonic.json.Parser
 
-import scala.StringContext
+import scala.{List, StringContext}
 import scala.util.{Left, Right}
 
 import java.lang.String
@@ -36,9 +36,12 @@ package object json {
   def parseRowAs(expected: Event*): Matcher[String] =
     parseAs(expected :+ Event.FinishRow: _*)
 
-  def parseAs(expected: Event*): Matcher[String] = { input: String =>
+  def parseAs(expected: Event*): Matcher[String] =
+    parseAsWithPlate(expected: _*)(p => p)
+
+  def parseAsWithPlate(expected: Event*)(f: Plate[List[Event]] => Plate[List[Event]]): Matcher[String] = { input: String =>
     val resultsF = for {
-      parser <- Parser(ReifiedTerminalPlate[IO], Parser.ValueStream)
+      parser <- Parser(ReifiedTerminalPlate[IO].map(f), Parser.ValueStream)
       left <- parser.absorb(input)
       right <- parser.finish
     } yield (left, right)

--- a/test/src/test/scala/tectonic/json/ParserSpecs.scala
+++ b/test/src/test/scala/tectonic/json/ParserSpecs.scala
@@ -304,9 +304,9 @@ object ParserSpecs extends Specification {
       input must parseAsWithPlate(expected: _*)(targetMask[List[Event]](Right("c")))
     }
 
-    "skip [0] and [2] in [..., ..., ...]" in {
+    "retain only [1] in [..., ..., ..., ...]" in {
       val input = """[42, "hi", true, null]"""
-      val expected = List(Skipped(2), NestArr, Str("hi"), Unnest, Skipped(5), Skipped(6), Skipped(5), FinishRow)
+      val expected = List(Skipped(2), NestArr, Str("hi"), Unnest, Skipped(5), Skipped(5), FinishRow)
       input must parseAsWithPlate(expected: _*)(targetMask[List[Event]](Left(1)))
     }
 
@@ -345,7 +345,7 @@ object ParserSpecs extends Specification {
 
       val (first, second, third) = eff.unsafeRunSync()
 
-      first must beRight(List(Skipped(2), Skipped(1)))
+      first must beRight(List(Skipped(3)))
       second must beRight(expected)
       third must beRight(Nil)
     }

--- a/test/src/test/scala/tectonic/json/ParserSpecs.scala
+++ b/test/src/test/scala/tectonic/json/ParserSpecs.scala
@@ -298,6 +298,12 @@ object ParserSpecs extends Specification {
       input must parseAsWithPlate(expected: _*)(targetMask[List[Event]](Right("b")))
     }
 
+    "skip .a and .b in { a: { no: ..., thanks: ... }, b: ..., c: ... }" in {
+      val input = """{ "a": { "no": 42, "thanks": null }, "b": "hi", "c": true }"""
+      val expected = List(NestMap("c"), Tru, Unnest, FinishRow)
+      input must parseAsWithPlate(expected: _*)(targetMask[List[Event]](Right("c")))
+    }
+
     "skip [0] and [2] in [..., ..., ...]" in {
       val input = """[42, "hi", true, null]"""
       val expected = List(NestArr, Str("hi"), Unnest, FinishRow)


### PR DESCRIPTION
What it says on the tin. In a contrived benchmark (which does not represent a theoretical best-case for the technique), this result in a roughly 3.5x performance improvement. I made no effort to optimize the scan such that HotSpot would emit vectorized assembly. This should be possible (@kRITZCREEK and I discussed at some length how we can go about doing this), but I don't think it's necessary for a first pass.

[ch3276]