### PR TITLE
Fixed typo'd source/target arraycopy in checkHeader

### DIFF
--- a/core/src/main/scala/tectonic/csv/Parser.scala
+++ b/core/src/main/scala/tectonic/csv/Parser.scala
@@ -471,7 +471,7 @@ final class Parser[F[_], A](plate: Plate[A], config: Parser.Config) extends Base
     if (column >= header.length) {
       val old = header
       header = new Array[CharSequence](old.length * 2)
-      System.arraycopy(header, 0, old, 0, old.length)
+      System.arraycopy(old, 0, header, 0, old.length)
     }
   }
 

--- a/test/src/test/scala/tectonic/csv/ParserSpecs.scala
+++ b/test/src/test/scala/tectonic/csv/ParserSpecs.scala
@@ -97,7 +97,7 @@ object ParserSpecs extends Specification {
           List(NestMap(header), Str(i.toString), Unnest)
       }
 
-      input must parseAs(generated ::: List(FinishRow): _*)
+      (input + input) must parseAs(generated ::: List(FinishRow) ::: generated ::: List(FinishRow): _*)
     }
 
     "parse a single value with a row ending in EOF" in {


### PR DESCRIPTION
Just a simple source/destination swap. We were testing up to length 52, but we weren't checking that it persisted beyond the first row.

Fixes #28
[ch3308]