### PR TITLE
ReplayPlate and EventCursor

### DIFF
--- a/benchmarks/src/main/scala/tectonic/BlackholePlate.scala
+++ b/benchmarks/src/main/scala/tectonic/BlackholePlate.scala
@@ -98,6 +98,8 @@ final class BlackholePlate private (
     consumeCPU(batchCost)
     List.empty[Nothing]
   }
+
+  def skipped(bytes: Int): Unit = ()
 }
 
 object BlackholePlate {

--- a/benchmarks/src/main/scala/tectonic/csv/ParserBenchmarks.scala
+++ b/benchmarks/src/main/scala/tectonic/csv/ParserBenchmarks.scala
@@ -92,6 +92,8 @@ class ParserBenchmarks {
           count = 0
           back
         }
+
+        def skipped(bytes: Int) = ()
       }
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,9 @@ lazy val test = project
   .dependsOn(core)
   .settings(name := "tectonic-test")
   .settings(
-    libraryDependencies += "org.specs2" %% "specs2-core" % "4.3.4")
+    libraryDependencies ++= Seq(
+      "org.specs2" %% "specs2-core" % "4.3.4",
+      "org.scalacheck" %% "scalacheck" % "1.14.0"))
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val benchmarks = project

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,9 @@ lazy val test = project
   .settings(
     libraryDependencies ++= Seq(
       "org.specs2" %% "specs2-core" % "4.3.4",
-      "org.scalacheck" %% "scalacheck" % "1.14.0"))
+      "org.scalacheck" %% "scalacheck" % "1.14.0"),
+
+    libraryDependencies += "org.specs2" %% "specs2-scalacheck" % "4.3.4" % Test)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val benchmarks = project

--- a/core/src/main/scala/tectonic/EventCursor.scala
+++ b/core/src/main/scala/tectonic/EventCursor.scala
@@ -18,6 +18,7 @@ package tectonic
 
 import scala.{sys, Array, Boolean, Int, Long, StringContext, Unit}
 import scala.annotation.switch
+// import scala.Predef, Predef._
 
 import java.lang.{CharSequence, SuppressWarnings}
 
@@ -29,16 +30,23 @@ import java.lang.{CharSequence, SuppressWarnings}
 final class EventCursor private (
     tagBuffer: Array[Long],
     tagLimit: Int,
-    tagSubshiftLimit: Int,
+    tagSubShiftLimit: Int,
     strsBuffer: Array[CharSequence],
     strsLimit: Int,
     intsBuffer: Array[Int],
     intsLimit: Int) {
 
   private[this] final var tagCursor: Int = 0
-  private[this] final var tagSubshiftCursor: Int = 0
+  private[this] final var tagSubShiftCursor: Int = 0
   private[this] final var strsCursor: Int = 0
   private[this] final var intsCursor: Int = 0
+
+  @SuppressWarnings(Array("org.wartremover.warts.While"))
+  def drive(plate: Plate[_]): Unit = {
+    if (tagLimit > 0 || tagSubShiftLimit > 0) {
+      while (next(plate)) {}
+    }
+  }
 
   // TODO skips
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
@@ -61,18 +69,18 @@ final class EventCursor private (
       case tag => sys.error(s"assertion failed: unrecognized tag = $tag")
     }
 
-    !(tagCursor == tagLimit && tagSubshiftCursor == tagSubshiftLimit)
+    !(tagCursor == tagLimit && tagSubShiftCursor == tagSubShiftLimit)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   private[this] final def nextTag(): Int = {
-    val back = ((tagBuffer(tagCursor) >>> tagSubshiftCursor) & 0xF).toInt
+    val back = ((tagBuffer(tagCursor) >>> tagSubShiftCursor) & 0xF).toInt
 
-    if (tagSubshiftCursor == 60) {
+    if (tagSubShiftCursor == 60) {
       tagCursor += 1
-      tagSubshiftCursor = 0
+      tagSubShiftCursor = 0
     } else {
-      tagSubshiftCursor += 4
+      tagSubShiftCursor += 4
     }
 
     back
@@ -92,7 +100,7 @@ final class EventCursor private (
 
   def reset(): Unit = {
     tagCursor = 0
-    tagSubshiftCursor = 0
+    tagSubShiftCursor = 0
     strsCursor = 0
     intsCursor = 0
   }
@@ -119,7 +127,7 @@ object EventCursor {
   private[tectonic] def apply(
       tagBuffer: Array[Long],
       tagLimit: Int,
-      tagSubshiftLimit: Int,
+      tagSubShiftLimit: Int,
       strsBuffer: Array[CharSequence],
       strsLimit: Int,
       intsBuffer: Array[Int],
@@ -128,7 +136,7 @@ object EventCursor {
     new EventCursor(
       tagBuffer,
       tagLimit,
-      tagSubshiftLimit,
+      tagSubShiftLimit,
       strsBuffer,
       strsLimit,
       intsBuffer,

--- a/core/src/main/scala/tectonic/EventCursor.scala
+++ b/core/src/main/scala/tectonic/EventCursor.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tectonic
+
+import scala.{sys, Array, Boolean, Int, Long, StringContext, Unit}
+import scala.annotation.switch
+
+import java.lang.{CharSequence, SuppressWarnings}
+
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.FinalVal",
+    "org.wartremover.warts.PublicInference",
+    "org.wartremover.warts.Var"))
+final class EventCursor private (
+    tagBuffer: Array[Long],
+    tagLimit: Int,
+    tagSubshiftLimit: Int,
+    strsBuffer: Array[CharSequence],
+    strsLimit: Int,
+    intsBuffer: Array[Int],
+    intsLimit: Int) {
+
+  private[this] final var tagCursor: Int = 0
+  private[this] final var tagSubshiftCursor: Int = 0
+  private[this] final var strsCursor: Int = 0
+  private[this] final var intsCursor: Int = 0
+
+  // TODO skips
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  def next(plate: Plate[_]): Boolean = {
+    // we can't use @switch if we use vals here :-(
+    val _ = (nextTag(): @switch) match {
+      case 0x0 => plate.nul()
+      case 0x1 => plate.fls()
+      case 0x2 => plate.tru()
+      case 0x3 => plate.map()
+      case 0x4 => plate.arr()
+      case 0x5 => plate.num(nextStr(), nextInt(), nextInt())
+      case 0x6 => plate.str(nextStr())
+      case 0x7 => plate.nestMap(nextStr())
+      case 0x8 => plate.nestArr()
+      case 0x9 => plate.nestMeta(nextStr())
+      case 0xA => plate.unnest()
+      case 0xB => plate.finishRow()
+      case 0xC => plate.skipped(nextInt())
+      case tag => sys.error(s"assertion failed: unrecognized tag = $tag")
+    }
+
+    !(tagCursor == tagLimit && tagSubshiftCursor == tagSubshiftLimit)
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  private[this] final def nextTag(): Int = {
+    val back = ((tagBuffer(tagCursor) >>> tagSubshiftCursor) & 0xF).toInt
+
+    if (tagSubshiftCursor == 60) {
+      tagCursor += 1
+      tagSubshiftCursor = 0
+    } else {
+      tagSubshiftCursor += 4
+    }
+
+    back
+  }
+
+  private[this] final def nextStr(): CharSequence = {
+    val back = strsBuffer(strsCursor)
+    strsCursor += 1
+    back
+  }
+
+  private[this] final def nextInt(): Int = {
+    val back = intsBuffer(intsCursor)
+    intsCursor += 1
+    back
+  }
+
+  def reset(): Unit = {
+    tagCursor = 0
+    tagSubshiftCursor = 0
+    strsCursor = 0
+    intsCursor = 0
+  }
+
+  // this will handle disk cleanup
+  def finish(): Unit = ()
+}
+
+object EventCursor {
+  private[tectonic] val Nul = 0x0
+  private[tectonic] val Fls = 0x1
+  private[tectonic] val Tru = 0x2
+  private[tectonic] val Map = 0x3
+  private[tectonic] val Arr = 0x4
+  private[tectonic] val Num = 0x5
+  private[tectonic] val Str = 0x6
+  private[tectonic] val NestMap = 0x7
+  private[tectonic] val NestArr = 0x8
+  private[tectonic] val NestMeta = 0x9
+  private[tectonic] val Unnest = 0xA
+  private[tectonic] val FinishRow = 0xB
+  private[tectonic] val Skipped = 0xC
+
+  private[tectonic] def apply(
+      tagBuffer: Array[Long],
+      tagLimit: Int,
+      tagSubshiftLimit: Int,
+      strsBuffer: Array[CharSequence],
+      strsLimit: Int,
+      intsBuffer: Array[Int],
+      intsLimit: Int)
+      : EventCursor =
+    new EventCursor(
+      tagBuffer,
+      tagLimit,
+      tagSubshiftLimit,
+      strsBuffer,
+      strsLimit,
+      intsBuffer,
+      intsLimit)
+}

--- a/core/src/main/scala/tectonic/Plate.scala
+++ b/core/src/main/scala/tectonic/Plate.scala
@@ -38,8 +38,7 @@ abstract class Plate[A] { self =>
   def finishRow(): Unit
   def finishBatch(terminal: Boolean): A
 
-  // TODO make this abstract in the next breaking release
-  def skipped(bytes: Int): Unit = ()
+  def skipped(bytes: Int): Unit
 
   final def mapDelegate[B](f: A => B): Plate[B] = new Plate[B] {
     def nul(): Signal = self.nul()

--- a/core/src/main/scala/tectonic/ReplayPlate.scala
+++ b/core/src/main/scala/tectonic/ReplayPlate.scala
@@ -159,7 +159,6 @@ final class ReplayPlate private (limit: Int) extends Plate[Option[EventCursor]] 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   private[this] final def checkTags(): Unit = {
     if (tagSubShift == 0 && tagPointer >= tagBuffer.length) {
-      scala.Predef.println("growing")
       val tagBuffer2 = new Array[Long](tagBuffer.length * 2)
       System.arraycopy(tagBuffer, 0, tagBuffer2, 0, tagBuffer.length)
       tagBuffer = tagBuffer2

--- a/core/src/main/scala/tectonic/ReplayPlate.scala
+++ b/core/src/main/scala/tectonic/ReplayPlate.scala
@@ -18,10 +18,10 @@ package tectonic
 
 import cats.effect.Sync
 
-import scala.{Array, Boolean, Int, Long, None, Option, Some, Unit}
-// import scala.{Predef, StringContext}, Predef._
+import scala.{Array, Boolean, Int, Long, None, Option, Some, StringContext, Unit}
+// import scala.{Predef}, Predef._
 
-import java.lang.{CharSequence, SuppressWarnings, System}
+import java.lang.{CharSequence, IllegalStateException, SuppressWarnings, System}
 
 /**
  * Produces None until finishBatch(true) is called.
@@ -156,9 +156,13 @@ final class ReplayPlate private (limit: Int) extends Plate[Option[EventCursor]] 
     }
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.Throw"))
   private[this] final def checkTags(): Unit = {
     if (tagSubShift == 0 && tagPointer >= tagBuffer.length) {
+      if (tagBuffer.length * 2 > limit) {
+        throw new IllegalStateException(s"unable to grow EventCursor beyond $limit")
+      }
+
       val tagBuffer2 = new Array[Long](tagBuffer.length * 2)
       System.arraycopy(tagBuffer, 0, tagBuffer2, 0, tagBuffer.length)
       tagBuffer = tagBuffer2
@@ -171,9 +175,13 @@ final class ReplayPlate private (limit: Int) extends Plate[Option[EventCursor]] 
     strsPointer += 1
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.Throw"))
   private[this] final def checkStrs(): Unit = {
     if (strsPointer >= strsBuffer.length) {
+      if (strsBuffer.length * 2 > limit) {
+        throw new IllegalStateException(s"unable to grow EventCursor beyond $limit")
+      }
+
       val strsBuffer2 = new Array[CharSequence](strsBuffer.length * 2)
       System.arraycopy(strsBuffer, 0, strsBuffer2, 0, strsBuffer.length)
       strsBuffer = strsBuffer2
@@ -186,9 +194,13 @@ final class ReplayPlate private (limit: Int) extends Plate[Option[EventCursor]] 
     intsPointer += 1
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.Throw"))
   private[this] final def checkInts(): Unit = {
     if (intsPointer >= intsBuffer.length) {
+      if (intsBuffer.length * 2 > limit) {
+        throw new IllegalStateException(s"unable to grow EventCursor beyond $limit")
+      }
+
       val intsBuffer2 = new Array[Int](intsBuffer.length * 2)
       System.arraycopy(intsBuffer, 0, intsBuffer2, 0, intsBuffer.length)
       intsBuffer = intsBuffer2

--- a/core/src/main/scala/tectonic/ReplayPlate.scala
+++ b/core/src/main/scala/tectonic/ReplayPlate.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tectonic
+
+import cats.effect.Sync
+
+import scala.{Array, Boolean, Int, Long, None, Option, Some, Unit}
+
+import java.lang.{CharSequence, SuppressWarnings, System}
+
+/**
+ * Produces None until finishBatch(true) is called.
+ */
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.Var",
+    "org.wartremover.warts.PublicInference",
+    "org.wartremover.warts.FinalVal"))
+final class ReplayPlate private (limit: Int) extends Plate[Option[EventCursor]] {
+
+  // everything fits into a word
+  private[this] final val Nul = EventCursor.Nul
+  private[this] final val Fls = EventCursor.Fls
+  private[this] final val Tru = EventCursor.Tru
+  private[this] final val Map = EventCursor.Map
+  private[this] final val Arr = EventCursor.Arr
+  private[this] final val Num = EventCursor.Num
+  private[this] final val Str = EventCursor.Str
+  private[this] final val NestMap = EventCursor.NestMap
+  private[this] final val NestArr = EventCursor.NestArr
+  private[this] final val NestMeta = EventCursor.NestMeta
+  private[this] final val Unnest = EventCursor.Unnest
+  private[this] final val FinishRow = EventCursor.FinishRow
+  private[this] final val Skipped = EventCursor.Skipped
+
+  private[this] final val Continue = Signal.Continue
+
+  private[this] var tagBuffer = new Array[Long](ReplayPlate.DefaultBufferSize)
+  private[this] var tagPointer = 0
+  private[this] var tagSubShift = 0
+
+  private[this] var strsBuffer = new Array[CharSequence](ReplayPlate.DefaultBufferSize / 2)
+  private[this] var strsPointer = 0
+
+  private[this] var intsBuffer = new Array[Int](ReplayPlate.DefaultBufferSize / 16)
+  private[this] var intsPointer = 0
+
+  final def nul(): Signal = {
+    appendTag(Nul)
+    Continue
+  }
+
+  final def fls(): Signal = {
+    appendTag(Fls)
+    Continue
+  }
+
+  final def tru(): Signal = {
+    appendTag(Tru)
+    Continue
+  }
+
+  final def map(): Signal = {
+    appendTag(Map)
+    Continue
+  }
+
+  final def arr(): Signal = {
+    appendTag(Arr)
+    Continue
+  }
+
+  final def num(s: CharSequence, decIdx: Int, expIdx: Int): Signal = {
+    appendTag(Num)
+    appendStr(s)
+    appendInt(decIdx)
+    appendInt(expIdx)
+    Continue
+  }
+
+  final def str(s: CharSequence): Signal = {
+    appendTag(Str)
+    appendStr(s)
+    Continue
+  }
+
+  final def nestMap(pathComponent: CharSequence): Signal = {
+    appendTag(NestMap)
+    appendStr(pathComponent)
+    Continue
+  }
+
+  final def nestArr(): Signal = {
+    appendTag(NestArr)
+    Continue
+  }
+
+  final def nestMeta(pathComponent: CharSequence): Signal = {
+    appendTag(NestMeta)
+    appendStr(pathComponent)
+    Continue
+  }
+
+  final def unnest(): Signal = {
+    appendTag(Unnest)
+    Continue
+  }
+
+  final def finishRow(): Unit = appendTag(FinishRow)
+
+  final def finishBatch(terminal: Boolean): Option[EventCursor] = {
+    if (terminal)
+      Some(
+        EventCursor(
+          tagBuffer,
+          tagPointer,
+          tagSubShift,
+          strsBuffer,
+          strsPointer,
+          intsBuffer,
+          intsPointer))
+    else
+      None
+  }
+
+  override final def skipped(bytes: Int): Unit = {
+    appendTag(Skipped)
+    appendInt(bytes)
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  private[this] final def appendTag(tag: Int): Unit = {
+    checkTags()
+    tagBuffer(tagPointer) |= tag << tagSubShift
+
+    if (tagSubShift == 60) {
+      tagPointer += 1
+      tagSubShift = 0
+    } else {
+      tagSubShift += 4
+    }
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  private[this] final def checkTags(): Unit = {
+    if (tagSubShift == 0 && tagPointer >= tagBuffer.length) {
+      val tagBuffer2 = new Array[Long](tagBuffer.length * 2)
+      System.arraycopy(tagBuffer, 0, tagBuffer2, 0, tagBuffer.length)
+      tagBuffer = tagBuffer2
+    }
+  }
+
+  private[this] final def appendStr(cs: CharSequence): Unit = {
+    checkStrs()
+    strsBuffer(strsPointer) = cs
+    strsPointer += 1
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  private[this] final def checkStrs(): Unit = {
+    if (strsPointer >= strsBuffer.length) {
+      val strsBuffer2 = new Array[CharSequence](strsBuffer.length * 2)
+      System.arraycopy(strsBuffer, 0, strsBuffer2, 0, strsBuffer.length)
+      strsBuffer = strsBuffer2
+    }
+  }
+
+  private[this] final def appendInt(i: Int): Unit = {
+    checkInts()
+    intsBuffer(intsPointer) = i
+    intsPointer += 1
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  private[this] final def checkInts(): Unit = {
+    if (intsPointer >= intsBuffer.length) {
+      val intsBuffer2 = new Array[Int](intsBuffer.length * 2)
+      System.arraycopy(intsBuffer, 0, intsBuffer2, 0, intsBuffer.length)
+      intsBuffer = intsBuffer2
+    }
+  }
+}
+
+object ReplayPlate {
+  val DefaultBufferSize: Int = 8 * 1024    // 8 KB
+
+  def apply[F[_]: Sync](limit: Int): F[Plate[Option[EventCursor]]] =
+    Sync[F].delay(new ReplayPlate(limit))
+}

--- a/core/src/main/scala/tectonic/ReplayPlate.scala
+++ b/core/src/main/scala/tectonic/ReplayPlate.scala
@@ -19,6 +19,7 @@ package tectonic
 import cats.effect.Sync
 
 import scala.{Array, Boolean, Int, Long, None, Option, Some, Unit}
+// import scala.{Predef, StringContext}, Predef._
 
 import java.lang.{CharSequence, SuppressWarnings, System}
 
@@ -145,7 +146,7 @@ final class ReplayPlate private (limit: Int) extends Plate[Option[EventCursor]] 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   private[this] final def appendTag(tag: Int): Unit = {
     checkTags()
-    tagBuffer(tagPointer) |= tag << tagSubShift
+    tagBuffer(tagPointer) |= tag.toLong << tagSubShift
 
     if (tagSubShift == 60) {
       tagPointer += 1
@@ -158,6 +159,7 @@ final class ReplayPlate private (limit: Int) extends Plate[Option[EventCursor]] 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   private[this] final def checkTags(): Unit = {
     if (tagSubShift == 0 && tagPointer >= tagBuffer.length) {
+      scala.Predef.println("growing")
       val tagBuffer2 = new Array[Long](tagBuffer.length * 2)
       System.arraycopy(tagBuffer, 0, tagBuffer2, 0, tagBuffer.length)
       tagBuffer = tagBuffer2

--- a/fs2/src/test/scala/tectonic/fs2/StreamParserSpecs.scala
+++ b/fs2/src/test/scala/tectonic/fs2/StreamParserSpecs.scala
@@ -37,7 +37,7 @@ object StreamParserSpecs extends Specification {
   import Event._
 
   val parserF: IO[BaseParser[IO, List[Event]]] =
-    Parser(ReifiedTerminalPlate[IO], Parser.ValueStream)
+    Parser(ReifiedTerminalPlate[IO](), Parser.ValueStream)
 
   val parser: Pipe[IO, Byte, Event] =
     StreamParser.foldable(parserF)

--- a/test/src/main/scala/tectonic/test/Generators.scala
+++ b/test/src/main/scala/tectonic/test/Generators.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tectonic
+package test
+
+import org.scalacheck.{Arbitrary, Gen}
+
+import scala.{AnyVal, Array, Boolean, Char, Int, Predef, Unit}, Predef._
+import scala.language.postfixOps
+
+import java.lang.SuppressWarnings
+
+object Generators {
+  import Arbitrary.arbitrary
+
+  type GenF[A] = Gen[Plate[A] => Unit]
+
+  implicit def arbitraryPlateF[A]: Arbitrary[Plate[A] => Unit] =
+    Arbitrary(genPlate[A])
+
+  def genPlate[A]: GenF[A] =
+    Gen.frequency(
+      20000 -> genRow[A] *>> genFinishRow[A],
+      1 -> genFinishBatch[A])
+
+  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+  def genRow[A]: GenF[A] =
+    Gen.oneOf(
+      genNul[A],
+      genFls[A],
+      genTru[A],
+      genMap[A],
+      genArr[A],
+      genNum[A],
+      genStr[A],
+      Gen.delay(genNestMap[A] *>> genRow[A] *>> genUnnest[A]),
+      Gen.delay(genNestArr[A] *>> genRow[A] *>> genUnnest[A]),
+      Gen.delay(genNestMeta[A] *>> genRow[A] *>> genUnnest[A]),
+      genSkipped[A])
+
+  def genFinishRow[A]: GenF[A] =
+    Gen.const(p => p.finishRow())
+
+  def genFinishBatch[A]: GenF[A] = {
+    Gen const { p =>
+      val _ = p.finishBatch(false)
+      ()
+    }
+  }
+
+  def genNul[A]: GenF[A] = {
+    Gen const { p =>
+      val _ = p.nul()
+      ()
+    }
+  }
+
+  def genFls[A]: GenF[A] = {
+    Gen const { p =>
+      val _ = p.fls()
+      ()
+    }
+  }
+
+
+  def genTru[A]: GenF[A] = {
+    Gen const { p =>
+      val _ = p.tru()
+      ()
+    }
+  }
+
+  def genMap[A]: GenF[A] = {
+    Gen const { p =>
+      val _ = p.map()
+      ()
+    }
+  }
+
+  def genArr[A]: GenF[A] = {
+    Gen const { p =>
+      val _ = p.arr()
+      ()
+    }
+  }
+
+  // I mean, it's not that hard to do this right. may as well
+  // note that this is more robust than generating doubles since we can get much larger numbers
+  @SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
+  def genNum[A]: GenF[A] = {
+    val genNumberStr =
+      Gen.containerOf[λ[α => String], Char](Gen.choose('0', '9')).filter(_.length > 0)
+
+    for {
+      negative <- arbitrary[Boolean]
+      integer <- genNumberStr
+
+      hasDecimal <- arbitrary[Boolean]
+      decimal <- if (hasDecimal)
+        genNumberStr.map("." +)
+      else
+        Gen.const("")
+
+      hasExponent <- arbitrary[Boolean]
+      exponent <- if (hasExponent)
+        genNumberStr.map("e" +)
+      else
+        Gen.const("")
+
+      str = (if (negative) "-" else "") + integer + decimal + exponent
+    } yield { p =>
+      val _ = p.num(str, str.indexOf("."), str.indexOf("e"))
+      ()
+    }
+  }
+
+  def genStr[A]: GenF[A] = {
+    arbitrary[String] map { s =>
+      { p =>
+        val _ = p.str(s)
+        ()
+      }
+    }
+  }
+
+  def genNestMap[A]: GenF[A] = {
+    arbitrary[String] map { s =>
+      { p =>
+        val _ = p.nestMap(s)
+        ()
+      }
+    }
+  }
+
+  def genNestArr[A]: GenF[A] = {
+    Gen const { p =>
+      val _ = p.nestArr()
+      ()
+    }
+  }
+
+  def genNestMeta[A]: GenF[A] = {
+    arbitrary[String] map { s =>
+      { p =>
+        val _ = p.nestMeta(s)
+        ()
+      }
+    }
+  }
+
+  def genUnnest[A]: GenF[A] = {
+    Gen const { p =>
+      val _ = p.unnest()
+      ()
+    }
+  }
+
+  def genSkipped[A]: GenF[A] = {
+    arbitrary[Int] map { i =>
+      { p =>
+        val _ = p.skipped(i)
+        ()
+      }
+    }
+  }
+
+  private implicit class GenFSyntax[A](val gf: Gen[A => Unit]) extends AnyVal {
+    def *>>(gf2: Gen[A => Unit]): Gen[A => Unit] = {
+      for {
+        f <- gf
+        f2 <- gf2
+      } yield { a =>
+        f(a)
+        f2(a)
+      }
+    }
+  }
+}

--- a/test/src/main/scala/tectonic/test/ReifiedTerminalPlate.scala
+++ b/test/src/main/scala/tectonic/test/ReifiedTerminalPlate.scala
@@ -111,7 +111,7 @@ final class ReifiedTerminalPlate private (accumToTerminal: Boolean) extends Plat
 object ReifiedTerminalPlate {
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-  def apply[F[_]: Sync](accumToTerminal: Boolean = false): F[Plate[List[Event]]] =
+  def apply[F[_]: Sync](accumToTerminal: Boolean = true): F[Plate[List[Event]]] =
     Sync[F].delay(new ReifiedTerminalPlate(accumToTerminal))
 
   def visit[A](events: List[Event], plate: Plate[A]): A = {

--- a/test/src/main/scala/tectonic/test/ReifiedTerminalPlate.scala
+++ b/test/src/main/scala/tectonic/test/ReifiedTerminalPlate.scala
@@ -19,7 +19,7 @@ package test
 
 import cats.effect.Sync
 
-import scala.{Array, Boolean, Int, List, Unit}
+import scala.{Array, Boolean, Int, List, Nil, Unit}
 import scala.collection.mutable
 
 import java.lang.{CharSequence, SuppressWarnings}
@@ -29,7 +29,7 @@ import java.lang.{CharSequence, SuppressWarnings}
     "org.wartremover.warts.NonUnitStatements",
     "org.wartremover.warts.Var",
     "org.wartremover.warts.TraversableOps"))
-final class ReifiedTerminalPlate private () extends Plate[List[Event]] {
+final class ReifiedTerminalPlate private (accumToTerminal: Boolean) extends Plate[List[Event]] {
   import Event._
 
   private val events = new mutable.ListBuffer[Event]
@@ -92,9 +92,13 @@ final class ReifiedTerminalPlate private () extends Plate[List[Event]] {
   def finishRow(): Unit = events += FinishRow
 
   def finishBatch(terminal: Boolean): List[Event] = {
-    val back = events.toList
-    events.clear()
-    back
+    if (accumToTerminal || terminal) {
+      val back = events.toList
+      events.clear()
+      back
+    } else {
+      Nil
+    }
   }
 
   override def skipped(bytes: Int): Unit = {
@@ -106,8 +110,9 @@ final class ReifiedTerminalPlate private () extends Plate[List[Event]] {
 
 object ReifiedTerminalPlate {
 
-  def apply[F[_]: Sync]: F[Plate[List[Event]]] =
-    Sync[F].delay(new ReifiedTerminalPlate())
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+  def apply[F[_]: Sync](accumToTerminal: Boolean = false): F[Plate[List[Event]]] =
+    Sync[F].delay(new ReifiedTerminalPlate(accumToTerminal))
 
   def visit[A](events: List[Event], plate: Plate[A]): A = {
     events foreach {

--- a/test/src/main/scala/tectonic/test/csv/package.scala
+++ b/test/src/main/scala/tectonic/test/csv/package.scala
@@ -38,7 +38,7 @@ package object csv {
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
   def parseAs(expected: Event*)(implicit config: Parser.Config): Matcher[String] = { input: String =>
     val resultsF = for {
-      parser <- Parser(ReifiedTerminalPlate[IO], config)
+      parser <- Parser(ReifiedTerminalPlate[IO](), config)
       left <- parser.absorb(input)
       right <- parser.finish
     } yield (left, right)
@@ -59,7 +59,7 @@ package object csv {
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
   def failParseWithError(errorPF: PartialFunction[ParseException, Result])(implicit config: Parser.Config): Matcher[String] = { input: String =>
     val resultsF = for {
-      parser <- Parser(ReifiedTerminalPlate[IO], config)
+      parser <- Parser(ReifiedTerminalPlate[IO](), config)
       left <- parser.absorb(input)
       right <- parser.finish
     } yield left.flatMap(xs => right.map(xs ::: _))

--- a/test/src/main/scala/tectonic/test/json/package.scala
+++ b/test/src/main/scala/tectonic/test/json/package.scala
@@ -41,7 +41,7 @@ package object json {
 
   def parseAsWithPlate(expected: Event*)(f: Plate[List[Event]] => Plate[List[Event]]): Matcher[String] = { input: String =>
     val resultsF = for {
-      parser <- Parser(ReifiedTerminalPlate[IO].map(f), Parser.ValueStream)
+      parser <- Parser(ReifiedTerminalPlate[IO]().map(f), Parser.ValueStream)
       left <- parser.absorb(input)
       right <- parser.finish
     } yield (left, right)

--- a/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
+++ b/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
@@ -1,0 +1,8 @@
+package tectonic
+package test
+
+import org.specs2.mutable._
+
+object ReplayPlateSpecs extends Specification {
+
+}

--- a/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
+++ b/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
@@ -84,6 +84,8 @@ object ReplayPlateSpecs extends Specification with ScalaCheck {
 
         def finishRow(): Unit = ()
         def finishBatch(terminal: Boolean) = ()
+
+        def skipped(bytes: Int) = ()
       }
 
       cursor.drive(sink)

--- a/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
+++ b/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
@@ -1,8 +1,94 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tectonic
 package test
 
+import cats.effect.IO
+
+import org.specs2.ScalaCheck
 import org.specs2.mutable._
 
-object ReplayPlateSpecs extends Specification {
+import scala.{Boolean, Int, List, Option, Predef, Unit}, Predef._
 
+import java.lang.{CharSequence, Runtime}
+
+object ReplayPlateSpecs extends Specification with ScalaCheck {
+  import Generators._
+
+  "ReplayPlate" should {
+    "round-trip events" in prop { (driver: ∀[λ[α => Plate[α] => Unit]]) =>
+      val plate = ReplayPlate[IO](-1).unsafeRunSync()
+      driver[Option[EventCursor]](plate)
+
+      val streamOpt = plate.finishBatch(true)
+      streamOpt must beSome
+      val stream = streamOpt.get
+
+      val eff = for {
+        resultP <- ReifiedTerminalPlate[IO](false)
+        expectedP <- ReifiedTerminalPlate[IO](false)
+
+        _ <- IO(stream.drive(resultP))
+        result <- IO(resultP.finishBatch(true))
+        _ <- IO(driver[List[Event]](expectedP))
+        expected <- IO(expectedP.finishBatch(true))
+      } yield (result, expected)
+
+      val (result, expected) = eff.unsafeRunSync()
+      result mustEqual expected
+    }.set(minTestsOk = 10000, workers = Runtime.getRuntime.availableProcessors())
+
+    "correctly the buffers" in {
+      val plate = ReplayPlate[IO](-1).unsafeRunSync()
+
+      (0 until 131072 + 1) foreach { _ =>
+        plate.nul()
+      }
+
+      val cursor = plate.finishBatch(true).get
+      var counter = 0
+
+      val sink = new Plate[Unit] {
+
+        def nul() = {
+          counter += 1
+          Signal.Continue
+        }
+
+        def fls(): Signal = Signal.Continue
+        def tru(): Signal = Signal.Continue
+        def map(): Signal = Signal.Continue
+        def arr(): Signal = Signal.Continue
+        def num(s: CharSequence, decIdx: Int, expIdx: Int): Signal = Signal.Continue
+        def str(s: CharSequence): Signal = Signal.Continue
+
+        def nestMap(pathComponent: CharSequence): Signal = Signal.Continue
+        def nestArr(): Signal = Signal.Continue
+        def nestMeta(pathComponent: CharSequence): Signal = Signal.Continue
+
+        def unnest(): Signal = Signal.Continue
+
+        def finishRow(): Unit = ()
+        def finishBatch(terminal: Boolean) = ()
+      }
+
+      cursor.drive(sink)
+
+      counter mustEqual (131072 + 1)
+    }
+  }
 }

--- a/test/src/test/scala/tectonic/json/ParserSpecs.scala
+++ b/test/src/test/scala/tectonic/json/ParserSpecs.scala
@@ -335,7 +335,7 @@ object ParserSpecs extends Specification {
 
       val eff = for {
         parser <- Parser(
-          ReifiedTerminalPlate[IO].map(targetMask[List[Event]](Right("b"))),
+          ReifiedTerminalPlate[IO]().map(targetMask[List[Event]](Right("b"))),
           Parser.ValueStream)
 
         first <- parser.absorb(input1)

--- a/test/src/test/scala/tectonic/json/ParserSpecs.scala
+++ b/test/src/test/scala/tectonic/json/ParserSpecs.scala
@@ -149,6 +149,8 @@ object ParserSpecs extends Specification {
 
         def finishRow(): Unit = ()
         def finishBatch(terminal: Boolean): Unit = calls += terminal
+
+        def skipped(bytes: Int) = ()
       }), Parser.ValueStream).unsafeRunSync()
 
       parser.absorb("42").unsafeRunSync() must beRight(())
@@ -178,6 +180,8 @@ object ParserSpecs extends Specification {
 
         def finishRow(): Unit = ()
         def finishBatch(terminal: Boolean): Unit = calls += terminal
+
+        def skipped(bytes: Int) = ()
       }), Parser.ValueStream).unsafeRunSync()
 
       parser.absorb("\"h").unsafeRunSync() must beRight(())


### PR DESCRIPTION
There's no limiting in place just yet, nor is there any spilling, but they work! They also appear to be fairly fast, just judging by how fast the tests are.

Also, assuming we set an in-memory tag limit of 256 MB (which is still a TON of contiguous memory), we would have a maximum number of events of (256 / 8) * 1024 * 1024 * 16 = 536,870,912. That's pretty decent! Each tag usually corresponds to a JSON fragment that takes up many many bytes even without whitespace. If we assume a normalized tag cost in text of 15 bytes (*shrug*), that means we can fit a roughly 7.5 GB row into memory. Should be enough for anyone(tm).

But seriously though, spilling is easy, and we'll probably want to do it long before our array eats up 256 MB of contiguous memory.

[ch3797]