### PR TITLE
Marking and row cursoring

### DIFF
--- a/core/src/main/scala/tectonic/EventCursor.scala
+++ b/core/src/main/scala/tectonic/EventCursor.scala
@@ -72,6 +72,8 @@ final class EventCursor private (
     !(tagCursor == tagLimit && tagSubShiftCursor == tagSubShiftLimit)
   }
 
+  def length: Int = tagLimit * (64 / 4) + (tagSubShiftLimit / 4)
+
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   private[this] final def nextTag(): Int = {
     val back = ((tagBuffer(tagCursor) >>> tagSubShiftCursor) & 0xF).toInt

--- a/core/src/main/scala/tectonic/EventCursor.scala
+++ b/core/src/main/scala/tectonic/EventCursor.scala
@@ -41,6 +41,11 @@ final class EventCursor private (
   private[this] final var strsCursor: Int = 0
   private[this] final var intsCursor: Int = 0
 
+  private[this] final var tagCursorMark: Int = 0
+  private[this] final var tagSubShiftCursorMark: Int = 0
+  private[this] final var strsCursorMark: Int = 0
+  private[this] final var intsCursorMark: Int = 0
+
   @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.While"))
   def drive(plate: Plate[_]): Unit = {
     if (tagLimit > 0 || tagSubShiftLimit > 0) {
@@ -104,6 +109,28 @@ final class EventCursor private (
   }
 
   def length: Int = tagLimit * (64 / 4) + (tagSubShiftLimit / 4)
+
+  /**
+   * Marks the current location for subsequent rewinding. Overwrites any previous
+   * mark.
+   */
+  def mark(): Unit = {
+    tagCursorMark = tagCursor
+    tagSubShiftCursorMark = tagSubShiftCursor
+    strsCursorMark = strsCursor
+    intsCursorMark = intsCursor
+  }
+
+  /**
+   * Rewinds the cursor location to the last mark. If no mark has been set,
+   * it resets to the beginnning of the stream.
+   */
+  def rewind(): Unit = {
+    tagCursor = tagCursorMark
+    tagSubShiftCursor = tagSubShiftCursorMark
+    strsCursor = strsCursorMark
+    intsCursor = intsCursorMark
+  }
 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   private[this] final def nextTag(): Int = {

--- a/core/src/main/scala/tectonic/EventCursor.scala
+++ b/core/src/main/scala/tectonic/EventCursor.scala
@@ -123,7 +123,7 @@ final class EventCursor private (
 
   /**
    * Rewinds the cursor location to the last mark. If no mark has been set,
-   * it resets to the beginnning of the stream.
+   * it resets to the beginning of the stream.
    */
   def rewind(): Unit = {
     tagCursor = tagCursorMark

--- a/test/src/main/scala/tectonic/test/Generators.scala
+++ b/test/src/main/scala/tectonic/test/Generators.scala
@@ -189,7 +189,7 @@ object Generators {
   }
 
   def genSkipped[A]: GenF[A] = {
-    arbitrary[Int] map { i =>
+    Gen.posNum[Int].filter(_ > 0) map { i =>
       { p =>
         val _ = p.skipped(i)
         ()

--- a/test/src/main/scala/tectonic/test/ReifiedTerminalPlate.scala
+++ b/test/src/main/scala/tectonic/test/ReifiedTerminalPlate.scala
@@ -114,7 +114,7 @@ object ReifiedTerminalPlate {
   def apply[F[_]: Sync](accumToTerminal: Boolean = true): F[Plate[List[Event]]] =
     Sync[F].delay(new ReifiedTerminalPlate(accumToTerminal))
 
-  def visit[A](events: List[Event], plate: Plate[A]): A = {
+  def visit[F[_]: Sync, A](events: List[Event], plate: Plate[A]): F[A] = Sync[F] delay {
     events foreach {
       case Event.Nul => plate.nul()
       case Event.Fls => plate.fls()

--- a/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
+++ b/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
@@ -94,7 +94,6 @@ object ReplayPlateSpecs extends Specification with ScalaCheck {
         firstP <- ReifiedTerminalPlate[IO](false)
 
         _ <- IO {
-          stream.mark()
           stream.nextRow(firstP)
         }
 

--- a/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
+++ b/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
@@ -49,6 +49,7 @@ object ReplayPlateSpecs extends Specification with ScalaCheck {
       } yield (result, expected)
 
       val (result, expected) = eff.unsafeRunSync()
+      stream.length mustEqual expected.length
       result mustEqual expected
     }.set(minTestsOk = 10000, workers = Runtime.getRuntime.availableProcessors())
 


### PR DESCRIPTION
Adds `EventCursor#mark`/`rewind`, which are necessary for backtracking during cartesian evaluation.  Also converted `EventCursor#next` to `nextRow`, which is necessary due to the fact that we page over the entire row, rather than one event at a time, during evaluation. Also cleaned up a couple random things.