### PR TITLE
EventCursor#subdivide

### DIFF
--- a/core/src/main/scala/tectonic/EventCursor.scala
+++ b/core/src/main/scala/tectonic/EventCursor.scala
@@ -123,7 +123,7 @@ final class EventCursor private (
     }
 
     val back = mutable.ListBuffer[EventCursor]()
-    val increment = math.ceil(bound.toFloat / (64 / 4)).toInt
+    val increment = math.max(math.round(bound.toFloat / (64 / 4)).toInt, 1)
 
     (0 until (tagLimit + 1) by increment).foldLeft((0, 0)) {
       case ((so, io), b) =>

--- a/core/src/main/scala/tectonic/EventCursor.scala
+++ b/core/src/main/scala/tectonic/EventCursor.scala
@@ -149,7 +149,7 @@ final class EventCursor private (
             val tag = tagBuffer2(i)
 
             var offset = 0
-            while (offset < 64) {   // we don't have to worry about tagSubshiftLimit, since we're not here if (last)
+            while (offset < 64) {   // we don't have to worry about tagSubShiftLimit, since we're not here if (last)
               (((tag >>> offset) & 0xF).toInt: @switch) match {
                 case 0x5 =>
                   strCount += 1

--- a/core/src/main/scala/tectonic/EventCursor.scala
+++ b/core/src/main/scala/tectonic/EventCursor.scala
@@ -126,23 +126,23 @@ final class EventCursor private (
     val increment = math.max(math.round(bound.toFloat / (64 / 4)).toInt, 1)
 
     (0 until (tagLimit + 1) by increment).foldLeft((0, 0)) {
-      case ((so, io), b) =>
-        val last = !(b < tagLimit + 1 - increment)
+      case ((strsOffset, intsOffset), current) =>
+        val last = !(current < tagLimit + 1 - increment)
 
         val length = if (last)
-          tagLimit + 1 - b
+          tagLimit + 1 - current
         else
           increment
 
         val tagBuffer2 = new Array[Long](length)
-        System.arraycopy(tagBuffer, b, tagBuffer2, 0, length)
+        System.arraycopy(tagBuffer, current, tagBuffer2, 0, length)
 
         var strCount = 0
         var intCount = 0
 
         if (last) {
-          strCount = strsLimit - so
-          intCount = intsLimit - io
+          strCount = strsLimit - strsOffset
+          intCount = intsLimit - intsOffset
         } else {
           var i = 0
           while (i < length) {
@@ -172,10 +172,10 @@ final class EventCursor private (
         }
 
         val strsBuffer2 = new Array[CharSequence](strCount)
-        System.arraycopy(strsBuffer, so, strsBuffer2, 0, strCount)
+        System.arraycopy(strsBuffer, strsOffset, strsBuffer2, 0, strCount)
 
         val intsBuffer2 = new Array[Int](intCount)
-        System.arraycopy(intsBuffer, io, intsBuffer2, 0, intCount)
+        System.arraycopy(intsBuffer, intsOffset, intsBuffer2, 0, intCount)
 
         back += new EventCursor(
           tagBuffer2,
@@ -186,7 +186,7 @@ final class EventCursor private (
           intsBuffer2,
           intCount)
 
-        (so + strCount, io + intCount)
+        (strsOffset + strCount, intsOffset + intCount)
     }
 
     back.toList

--- a/core/src/main/scala/tectonic/EventCursor.scala
+++ b/core/src/main/scala/tectonic/EventCursor.scala
@@ -127,7 +127,7 @@ final class EventCursor private (
 
     (0 until (tagLimit + 1) by increment).foldLeft((0, 0)) {
       case ((strsOffset, intsOffset), current) =>
-        val last = !(current < tagLimit + 1 - increment)
+        val last = current + increment > tagLimit
 
         val length = if (last)
           tagLimit + 1 - current

--- a/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
+++ b/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
@@ -104,7 +104,7 @@ object ReplayPlateSpecs extends Specification with ScalaCheck {
             val lengths = partitions.map(_.length)
 
             lengths.sum mustEqual stream.length
-            lengths must contain(be_>=(size))
+            lengths must contain(be_>=((size / 16) * 16))
 
             val origEff =
               ReifiedTerminalPlate[IO](false) flatMap { plate =>


### PR DESCRIPTION
This is ultimately necessary to enable parallel cartesian evaluation in `Engraver`. Note that the `bound` parameter passed to `subdivide` is treated as a hint, and this is by design. The intention is to basically just get relatively close to that bound, but quantized to the bitsize of the `Long` to avoid pathological slow requantization.