### PR TITLE
Added EventCursor#copy

### DIFF
--- a/core/src/main/scala/tectonic/EventCursor.scala
+++ b/core/src/main/scala/tectonic/EventCursor.scala
@@ -165,6 +165,17 @@ final class EventCursor private (
     intsCursor = 0
   }
 
+  def copy(): EventCursor = {
+    new EventCursor(
+      tagBuffer,
+      tagLimit,
+      tagSubShiftLimit,
+      strsBuffer,
+      strsLimit,
+      intsBuffer,
+      intsLimit)
+  }
+
   // this will handle disk cleanup
   def finish(): Unit = ()
 }


### PR DESCRIPTION
Trivial little feature needed because `EventCursor` is an internal iterator, meaning we cannot use the same cursor in multiple threads simultaneously.