### PR TITLE
UTF-8 Byte Order Mark Handling

### DIFF
--- a/core/src/main/scala/tectonic/BaseParser.scala
+++ b/core/src/main/scala/tectonic/BaseParser.scala
@@ -91,6 +91,14 @@ abstract class BaseParser[F[_], A] {
     resizeIfNecessary(need)
     buf.get(data, len, buflen)
     len = need
+
+    // ignore BOM
+    if (line == 0 && pos == 0 && offset == 0 && len >= 3) {
+      if (data(0) == 0xef.toByte && data(1) == 0xbb.toByte && data(2) == 0xbf.toByte) {
+        offset = 3
+      }
+    }
+
     churn()
   }
 

--- a/core/src/main/scala/tectonic/BaseParser.scala
+++ b/core/src/main/scala/tectonic/BaseParser.scala
@@ -83,7 +83,8 @@ abstract class BaseParser[F[_], A] {
   @SuppressWarnings(
     Array(
       "org.wartremover.warts.NonUnitStatements",
-      "org.wartremover.warts.Overloading"))
+      "org.wartremover.warts.Overloading",
+      "org.wartremover.warts.Equals"))
   final def absorb(buf: ByteBuffer)(implicit F: Sync[F]): F[Either[ParseException, A]] = F delay {
     done = false
     val buflen = buf.limit() - buf.position()

--- a/harness/src/main/scala/tectonic/harness/RowCountHarness.scala
+++ b/harness/src/main/scala/tectonic/harness/RowCountHarness.scala
@@ -94,6 +94,8 @@ object RowCountHarness {
             count = 0
             back
           }
+
+          def skipped(bytes: Int) = ()
         }
       }
     }

--- a/test/src/main/scala/tectonic/test/json/Absorbable.scala
+++ b/test/src/main/scala/tectonic/test/json/Absorbable.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tectonic
+package test
+
+import cats.effect.IO
+
+import java.lang.String
+import java.nio.ByteBuffer
+
+import scala.{Array, Byte}
+import scala.util.Either
+
+sealed trait Absorbable[A] {
+  def absorb[B](p: BaseParser[IO, B], a: A): IO[Either[ParseException, B]]
+}
+
+object Absorbable {
+
+  def apply[A](implicit A: Absorbable[A]): Absorbable[A] = A
+
+  implicit object StringAbs extends Absorbable[String] {
+    def absorb[B](p: BaseParser[IO, B], str: String): IO[Either[ParseException, B]] =
+      p.absorb(str)
+  }
+
+  implicit object ByteBufferAbs extends Absorbable[ByteBuffer] {
+    def absorb[B](p: BaseParser[IO, B], bytes: ByteBuffer): IO[Either[ParseException, B]] =
+      p.absorb(bytes)
+  }
+
+  implicit object BArrayAbs extends Absorbable[Array[Byte]] {
+    def absorb[B](p: BaseParser[IO, B], bytes: Array[Byte]): IO[Either[ParseException, B]] =
+      p.absorb(bytes)
+  }
+}

--- a/test/src/main/scala/tectonic/test/json/package.scala
+++ b/test/src/main/scala/tectonic/test/json/package.scala
@@ -26,8 +26,6 @@ import tectonic.json.Parser
 import scala.{List, StringContext}
 import scala.util.{Left, Right}
 
-import java.lang.String
-
 package object json {
   private object MatchersImplicits extends MatchersImplicits
 


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Byte_order_mark

I didn't write a test for it, but this applies to CSV as well as JSON since `BaseParser` is used by both.

[ch5541]