### PR TITLE
Added count to EventCursor#rewind

### DIFF
--- a/core/src/main/scala/tectonic/EventCursor.scala
+++ b/core/src/main/scala/tectonic/EventCursor.scala
@@ -255,13 +255,19 @@ final class EventCursor private (
 
   /**
    * Rewinds the cursor location to the last mark. If no mark has been set,
-   * it resets to the beginning of the stream.
+   * it resets to the beginning of the stream. Returns the number of events
+   * rewound.
    */
-  def rewind(): Unit = {
+  def rewind(): Int = {
+    val tagCursorDistance = tagCursor - tagCursorMark
+    val tagSubShiftDistance = tagSubShiftCursor - tagSubShiftCursorMark
+
     tagCursor = tagCursorMark
     tagSubShiftCursor = tagSubShiftCursorMark
     strsCursor = strsCursorMark
     intsCursor = intsCursorMark
+
+    (tagCursorDistance * (64 / 4) + (tagSubShiftDistance / 4))
   }
 
   @SuppressWarnings(


### PR DESCRIPTION
Our counts are wrong in `Engraver#cross` because we don't have this. Marking as **feature** since it's binary-incompatible, though it should be source compatible in all cases.