### PR TITLE
Reset curr whenever we loop back through churn()

### DIFF
--- a/core/src/main/scala/tectonic/BaseParser.scala
+++ b/core/src/main/scala/tectonic/BaseParser.scala
@@ -175,6 +175,7 @@ abstract class BaseParser[F[_], A] {
 
   // every 1M we shift our array back to the beginning.
   protected[this] final def reset(i: Int): Int = {
+    // ...but over here, we don't consider `i` as part of our reset calculation! we just consider `offset`, which we haven't updated yet
     if (offset >= 1048576) {
       val diff = offset
       curr -= diff

--- a/core/src/main/scala/tectonic/BaseParser.scala
+++ b/core/src/main/scala/tectonic/BaseParser.scala
@@ -130,8 +130,8 @@ abstract class BaseParser[F[_], A] {
   final def absorb(s: String)(implicit F: Sync[F]): F[Either[ParseException, A]] =
     F.suspend(absorb(ByteBuffer.wrap(s.getBytes(BaseParser.Utf8))))
 
-  protected[this] final def unsafeData(): Array[Byte] = data
-  protected[this] final def unsafeLen(): Int = len
+  protected[tectonic] final def unsafeData(): Array[Byte] = data
+  protected[tectonic] final def unsafeLen(): Int = len
 
   /**
    * This is a specialized accessor for the case where our underlying data are
@@ -175,15 +175,14 @@ abstract class BaseParser[F[_], A] {
 
   // every 1M we shift our array back to the beginning.
   protected[this] final def reset(i: Int): Int = {
-    // ...but over here, we don't consider `i` as part of our reset calculation! we just consider `offset`, which we haven't updated yet
-    if (offset >= 1048576) {
-      val diff = offset
+    if (i >= 1048576) {
+      val diff = i
       curr -= diff
       len -= diff
       offset = 0
       pos -= diff
       System.arraycopy(data, diff, data, 0, len)
-      i - diff
+      0
     } else {
       i
     }

--- a/core/src/main/scala/tectonic/json/Parser.scala
+++ b/core/src/main/scala/tectonic/json/Parser.scala
@@ -259,6 +259,7 @@ final class Parser[F[_], A] private (
         } else {
           // jump straight back into rparse
           offset = reset(offset)
+          curr = reset(curr)    // we reset both of these, because offset only gets updated when the "row" finishes
 
           val j = if (state <= 0) {
             parse(offset)
@@ -711,6 +712,7 @@ final class Parser[F[_], A] private (
       "org.wartremover.warts.NonUnitStatements",
       "org.wartremover.warts.Equals"))
   protected[this] def rparse(state: Int, j: Int, ring: Long, offset: Int, fallback: BList): Int = {
+    // okay this is a problem. we reset(j) here...
     val i = reset(j)
     checkpoint(state, i, ring, offset, fallback)
 

--- a/core/src/main/scala/tectonic/json/Parser.scala
+++ b/core/src/main/scala/tectonic/json/Parser.scala
@@ -712,7 +712,6 @@ final class Parser[F[_], A] private (
       "org.wartremover.warts.NonUnitStatements",
       "org.wartremover.warts.Equals"))
   protected[this] def rparse(state: Int, j: Int, ring: Long, offset: Int, fallback: BList): Int = {
-    // okay this is a problem. we reset(j) here...
     val i = reset(j)
     checkpoint(state, i, ring, offset, fallback)
 

--- a/test/src/test/scala/tectonic/NullPlate.scala
+++ b/test/src/test/scala/tectonic/NullPlate.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014–2019 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tectonic
+
+import scala.{Boolean, Int, Unit}
+
+import java.lang.CharSequence
+
+object NullPlate extends Plate[Unit] {
+  def arr() = Signal.Continue
+  def finishBatch(terminal: Boolean) = ()
+  def finishRow() = ()
+  def fls() = Signal.Continue
+  def map() = Signal.Continue
+  def nestArr() = Signal.Continue
+  def nestMap(pathComponent: CharSequence) = Signal.Continue
+  def nestMeta(pathComponent: CharSequence) = Signal.Continue
+  def nul() = Signal.Continue
+  def num(s: CharSequence, decIdx: Int, expIdx: Int) = Signal.Continue
+  def skipped(bytes: Int) = ()
+  def str(s: CharSequence) = Signal.Continue
+  def tru() = Signal.Continue
+  def unnest() = Signal.Continue
+}

--- a/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
+++ b/test/src/test/scala/tectonic/ReplayPlateSpecs.scala
@@ -15,13 +15,14 @@
  */
 
 package tectonic
-package test
 
 import cats.effect.IO
 import cats.implicits._
 
 import org.specs2.ScalaCheck
 import org.specs2.mutable._
+
+import tectonic.test.{Event, Generators, ReifiedTerminalPlate}
 
 import scala._, Predef._
 
@@ -374,22 +375,5 @@ object ReplayPlateSpecs extends Specification with ScalaCheck {
     ec.reset()
 
     count
-  }
-
-  object NullPlate extends Plate[Unit] {
-    def arr() = Signal.Continue
-    def finishBatch(terminal: Boolean) = ()
-    def finishRow() = ()
-    def fls() = Signal.Continue
-    def map() = Signal.Continue
-    def nestArr() = Signal.Continue
-    def nestMap(pathComponent: CharSequence) = Signal.Continue
-    def nestMeta(pathComponent: CharSequence) = Signal.Continue
-    def nul() = Signal.Continue
-    def num(s: CharSequence,decIdx: Int,expIdx: Int) = Signal.Continue
-    def skipped(bytes: Int) = ()
-    def str(s: CharSequence) = Signal.Continue
-    def tru() = Signal.Continue
-    def unnest() = Signal.Continue
   }
 }


### PR DESCRIPTION
Bitten by the respective weird redundancy between `offset` and `curr`! I think. We weren't resetting the `data` array within rows, so if we had a really *really* long row, it would just load the whole thing into `data` and never page it out.

[ch10570]
[ch10573]